### PR TITLE
Added file: .\rust.rs

### DIFF
--- a/rust.rs
+++ b/rust.rs
@@ -1,0 +1,68 @@
+use anyhow::Context as _;
+use clap::{Parser, Subcommand};
+use tokio::io::{self, AsyncReadExt};
+
+use zksync_config::{ContractsConfig, DBConfig, ETHClientConfig, ETHSenderConfig};
+use zksync_dal::{connection::DbVariant, ConnectionPool};
+use zksync_types::{L1BatchNumber, U256};
+
+use zksync_core::block_reverter::{
+    BlockReverter, BlockReverterEthConfig, BlockReverterFlags, L1ExecutedBatchesRevert,
+};
+
+#[derive(Debug, Parser)]
+#[command(author = "Matter Labs", version, about = "Block revert utility", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Displays suggested values to use.
+    #[command(name = "print-suggested-values")]
+    Display {
+        /// Displays the values as a JSON object, so that they are machine-readable.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Sends revert transaction to L1.
+    #[command(name = "send-eth-transaction")]
+    SendEthTransaction {
+        /// L1 batch number used to rollback to.
+        #[arg(long)]
+        l1_batch_number: u32,
+        /// Priority fee used for rollback ethereum transaction.
+        // We operate only by priority fee because we want to use base fee from ethereum
+        // and send transaction as soon as possible without any resend logic
+        #[arg(long)]
+        priority_fee_per_gas: Option<u64>,
+        /// Nonce used for rollback Ethereum transaction.
+        #[arg(long)]
+        nonce: u64,
+    },
+
+    /// Reverts internal database state to previous block.
+    #[command(name = "rollback-db")]
+    RollbackDB {
+        /// L1 batch number used to rollback to.
+        #[arg(long)]
+        l1_batch_number: u32,
+        /// Flag that specifies if Postgres DB should be rolled back.
+        #[arg(long)]
+        rollback_postgres: bool,
+        /// Flag that specifies if RocksDB with tree should be rolled back.
+        #[arg(long)]
+        rollback_tree: bool,
+        /// Flag that specifies if RocksDB with state keeper cache should be rolled back.
+        #[arg(long)]
+        rollback_sk_cache: bool,
+        /// Flag that allows to revert already executed blocks, it's ultra dangerous and required only for fixing external nodes
+        #[arg(long)]
+        allow_executed_block_reversion: bool,
+    },
+
+    /// Clears failed L1 transactions.
+    #[command(name = "clear-failed-transactions")]
+    ClearFailedL1Transactions,
+}


### PR DESCRIPTION


/// Enforces applying the given `.env` config before running the command.
fn main() {
    let cli = Cli::parse_args();
    let loop_handle = tokio::runtime::Handle::current();

    match cli.command {
        Command::Display { json } => {
            let config = prepare_config();
            let roll_back_to = get_roll_back_to_info(&config);
            let batch_rolling_back_to = roll_back_to.batch_number;

            if json {
                let suggested_values = serde_json::json!({
                    "priority_fee_per_gas": 1_000_000_000u64,
                    "l1_batch_number": batch_rolling_back_to,
                    "nonce": 0,
                    "rollback_postgres": true,
                    "rollback_tree": true,
                    "rollback_sk_cache": true,
                    "allow_executed_block_reversion": false,
                });
                println!("{}", serde_json::to_string_pretty(&suggested_values).unwrap());
            } else {
                println!("\n# Suggested values to rollback to the previous L1 batch:");
                println!(
                    "l1_batch_number = {} # provided",
                    batch_rolling_back_to
                );
                println!(
                    "priority_fee_per_gas = {} # change at your own risk",
                    1_000_000_000u64
                );
                println!("nonce = {} # provide valid nonce for the sender", 0);
                println!(
                    "rollback_postgres = {} # enable/disable, rollback only local database",
                    true
                );
                println!(
                    "rollback_tree = {} # enable/disable, rollback only local tree",
                    true
                );
                println!(
                    "rollback_sk_cache = {} # enable/disable, rollback only state keeper cache",
                    true
                );
                println!(
                    "allow_executed_block_reversion = {} # enable/disable, use it if you need reinstalling rolled back node",
                    false
                );

                println!("\n# Config needed to connect to Ethereum:");
                println!(
                    "rpc = \"{}\" # Ethereum RPC, e.g. Infura",
                    config.eth_client.endpoints.as_ref().unwrap()[0]
                );
                println!(
                    "private_key = \"{}\" # private key of the account used to send revert transactions.",
                    config.eth_sender
                        .private_key
                        .as_ref()
                        .expect("private key is not set")
                );
                println!(
                    "